### PR TITLE
Fix gcc missing include

### DIFF
--- a/absl/strings/internal/str_format/extension.h
+++ b/absl/strings/internal/str_format/extension.h
@@ -19,6 +19,7 @@
 #include <limits.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <ostream>
 


### PR DESCRIPTION
# Changes

With GCC 13, the inclusion of indirect header files has changes in the standard library headers and as such we no longer indirectly get `cstdint` included automatically. This header file is necessary as `uint8_t` gets used below.
